### PR TITLE
Fixed TextCollate function to apply tokenizer on text_key before padding

### DIFF
--- a/captioning/datasets/collate_func.py
+++ b/captioning/datasets/collate_func.py
@@ -63,12 +63,12 @@ class TextCollate(VarLenPadCollate):
 
         for key in data_batch[0].keys():
             try:
-                if key in self.pad_keys:
+                if key == self.text_key:
+                    output.update(self.tokenizer(output[key]))
+                elif key in self.pad_keys:
                     padded_seq, length = pad_sequence(output[key])
                     output[key] = padded_seq
                     output[f"{key}_len"] = np.array(length)
-                elif key == self.text_key:
-                    output.update(self.tokenizer(output[key]))
                 else:
                     if isinstance(output[key][0], (np.ndarray, torch.Tensor)) and \
                         output[key][0].ndim > 1:


### PR DESCRIPTION
* Resolved an issue where pad_sequence was applied directly to raw text strings instead of tokenized input when the key was text_key.
* Now, the tokenizer is correctly called on text_key values, ensuring compatibility with pad_sequence (handled in `DictTokenizer`).